### PR TITLE
chore: update EOL 21.08 runtime to 23.08

### DIFF
--- a/io.github.hakuneko.HakuNeko.json
+++ b/io.github.hakuneko.HakuNeko.json
@@ -1,9 +1,9 @@
 {
 	"app-id": "io.github.hakuneko.HakuNeko",
 	"base": "org.electronjs.Electron2.BaseApp",
-	"base-version": "21.08",
+	"base-version": "22.08",
 	"runtime": "org.freedesktop.Platform",
-	"runtime-version": "21.08",
+	"runtime-version": "22.08",
 	"sdk": "org.freedesktop.Sdk",
 	"command": "hakuneko",
 	"separate-locales": false,

--- a/io.github.hakuneko.HakuNeko.json
+++ b/io.github.hakuneko.HakuNeko.json
@@ -1,9 +1,9 @@
 {
 	"app-id": "io.github.hakuneko.HakuNeko",
 	"base": "org.electronjs.Electron2.BaseApp",
-	"base-version": "22.08",
+	"base-version": "23.08",
 	"runtime": "org.freedesktop.Platform",
-	"runtime-version": "22.08",
+	"runtime-version": "23.08",
 	"sdk": "org.freedesktop.Sdk",
 	"command": "hakuneko",
 	"separate-locales": false,


### PR DESCRIPTION
[The 21.08 runtime is now EOL](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/wikis/Releases#information-about-current-releases), this PR bumps it to the current 23.08.

~~Not necessary *yet*, [21.08 isn't at EOL until October](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/wikis/Releases#information-about-current-releases), but will have to be done eventually. (Also, the rest of my flatpaks have updated and it'd be very satisfying to update my last 21.08 :) )~~

~~I built this locally and tested around for a few minutes, everything seemed to work fine and I didn't run into any issues.~~